### PR TITLE
api.baseUrl array entries must be valid URLs.

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -38,7 +38,7 @@
     }
   ],
   "api": {
-    "baseUrl": ["api-staging.speccheckrx.com", "api.speccheckrx.com"],
+    "baseUrl": ["https://api-staging.speccheckrx.com", "https://api.speccheckrx.com"],
     "playground": {
       "mode": "hide"
     }


### PR DESCRIPTION
they don't specify what is a valid url, so trying this